### PR TITLE
修复路径错误问题

### DIFF
--- a/main.py
+++ b/main.py
@@ -43,7 +43,7 @@ class MinecraftAudioPackGenerator:
     
     def __init__(self):
         self.config = {}
-        self.base_path = Path(__file__).parent
+                self.base_path = Path.cwd() # Fix: 使用Path(__file__) 会造成编译为exe运行后音频路径会出现在temp目录路径问题
         self.config_file = self.base_path / "config.json"
         self.audios_folder = self.base_path / "audios"
         self.output_folder = self.base_path / "resource_pack"
@@ -493,3 +493,4 @@ if __name__ == "__main__":
     except Exception as e:
         print(f"\n程序出现错误: {e}")
         input("按Enter键退出...")
+


### PR DESCRIPTION
Fix: 使用Path(__file__) 会造成编译为exe运行后音频路径会出现在temp目录路径问题